### PR TITLE
HighDPIScaling Disabled edildi.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
         return 0;
     }
     qmlRegisterType<Helper>("ps.helper",1,0,"Helper");
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
     QGuiApplication::setWindowIcon(QIcon(":/images/icon.svg"));
     QGuiApplication app(argc, argv);
 


### PR DESCRIPTION
Yüksek DPI'lı bilgisayarlarda ekrandan taşan bir görüntü oluşturuyor.

![ekran goruntusu_2018-08-09_19-42-17](https://user-images.githubusercontent.com/14258668/43913726-825a2ab4-9c0e-11e8-9b71-31a51cadf1b4.png)
![ekran goruntusu_2018-08-09_19-50-02](https://user-images.githubusercontent.com/14258668/43913728-8288219e-9c0e-11e8-8a5c-02db95576cde.png)
